### PR TITLE
refactor: queuing logic to increasing performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,29 +18,13 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# User-specific stuff:
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/dictionaries
-
-# Sensitive or high-churn files:
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.xml
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-
-# Gradle:
-.idea/**/gradle.xml
-.idea/**/libraries
+# Intellij
+.idea/
+# mpeltonen/sbt-idea plugin
+.idea_modules/
 
 # CMake
 cmake-build-debug/
-
-# Mongo Explorer plugin:
-.idea/**/mongoSettings.xml
 
 ## File-based project format:
 *.iws
@@ -50,14 +34,8 @@ cmake-build-debug/
 # IntelliJ
 out/
 
-# mpeltonen/sbt-idea plugin
-.idea_modules/
-
 # JIRA plugin
 atlassian-ide-plugin.xml
-
-# Cursive Clojure plugin
-.idea/replstate.xml
 
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
@@ -67,7 +45,4 @@ fabric.properties
 
 .vscode
 
-.idea/bqueue.iml
-.idea/encodings.xml
-.idea/misc.xml
-.idea/modules.xml
+/.gtm/

--- a/README.md
+++ b/README.md
@@ -14,51 +14,13 @@ BQUEUE
 
 Why
 ---
-We needed a simple and quick queue system. to handle request rapidely without impacting performance.
-Each of our job could take up to 20s to execute.
+We needed a simple and quick queue system to handle requests rapidly without impacting performance.
+Each of our jobs could take up to 20s to execute.
 
 How it works
 ----
-by using the awesomeness of channels
+By using the awesomeness of channels.
 
->Channels are the pipes that connect concurrent goroutines. You can send values into channels from one goroutine and receive those values into another goroutine
+>Channels are the pipes that all goroutines to share data. You can send values into channels from one goroutine and receive those values in another goroutine.
 
-With channels we are able to flow the data between states without any performance impact
-
-```
-  ┌─────────────────────────────────┐                             ┌───────────────────────────────┐
-  │Queue                            │                             │Worker                         │
-  │---                              │                             │---                            │
-  │    maxWorker   int              │                             │    ID          int            │
-  │    JobRequests chan chan Job    │                             │    JobHunting  chan Job       │
-  │    JobReceived chan Job         │                             │    jobRequests chan chan Job  │
-  │                                 │                             │    QuitChan    chan bool      │
-  │                                 │                             │                               │
-  │M: Start()                       │                             │                               │
-  │-                                │                             │                               │
-  │Also initialize the workers      │     ┌────────────────┐      │                               │
-  │and channels                     │     │ share the same │      │M: Start() |  goroutine        │
-  │                                 │     │    instance    │      │-                              │
-  │                                 │     ├────────────────┤  ┌──▶│Receive a job from JobRequests │
-  │M: CollectJob(j Job)             │     │JobRequests     │  │   │Calls do passing the job       │
-  │-                                │┌───▶│---             │──┘   │                               │
-  │adds the job to the JobReceived  ││    │(chan chan Job) │      │                               │
-  │                                 ││    └────────────────┘      │                               │
-  │                                 ││                            │M: do(j Job)                   │
-  │M: dispatch() | goroutine      ──┼┘                            │-                              │
-  │-                                │                             │process the job                │
-  │Looks for job in JobReceived     │                             │                               │
-  │Then add it to the JobRequests   │                             │                               │
-  │                                 │                             │                               │
-  │                                 │                             │                               │
-  │                                 │                             │                               │
-  │                                 │                             │                               │
-  │                                 │                             │                               │
-  │                                 │                             │                               │
-  │                                 │                             │                               │
-  │                                 │                             │                               │
-  │                                 │                             │                               │
-  │                                 │                             │                               │
-  │                                 │                             │                               │
-  └─────────────────────────────────┘                             └───────────────────────────────┘
-```
+With channels we are able to share the data between goroutines enabling it to be processed concurrently, to make the best use of multiple CPU cores.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/SamuelTissot/bqueue
 
+go 1.16
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,0 +1,11 @@
+package bqueue
+
+// Job is implemented by types which can be processed by Queue.
+type Job interface {
+	Process()
+}
+
+// Logger is implemented by types which an be used by Queue as a log destination.
+type Logger interface {
+	Printf(format string, v ...interface{})
+}

--- a/job.go
+++ b/job.go
@@ -1,7 +1,0 @@
-package bqueue
-
-// Job is an interface for the bqueue.
-// it must implement `func Process() err {}`
-type Job interface {
-	Process() error
-}

--- a/queue.go
+++ b/queue.go
@@ -1,56 +1,222 @@
 // Package bqueue is a "in memory" queue.
-//
-// it Collects jobs via the `CollectJob` func who takes a
-// interface `Job`
 package bqueue
 
-import "sync"
+import (
+	"context"
+	"fmt"
+	"log"
+	"runtime"
+	"sync"
+)
 
-var WG sync.WaitGroup
+const (
+	// DefaultLimit is the default job queue limit.
+	DefaultLimit = 128
 
-// Queue that process jobs reveived
+	// UnlimitedWorkers can passed to Workers when run in dynamic
+	// mode to use an unlimited amount of workers.
+	UnlimitedWorkers = -1
+)
+
+// Queue processes jobs.
 type Queue struct {
-	maxWorker   int
-	JobRequests chan chan Job
-	JobReceived chan Job
+	limiter chan struct{}
+	workers int
+	limit   int
+	run     func() error
+	jobs    chan Job
+	log     Logger
+	wg      sync.WaitGroup
 }
 
-// New Queue object
-// @param MaxWorkerint is the maximum job at a single time that can be handled
-func New(maxWorker int) *Queue {
-	JobRequests := make(chan chan Job, maxWorker)
-	return &Queue{
-		maxWorker:   maxWorker,
-		JobRequests: JobRequests,
-		JobReceived: make(chan Job, 128),
-	}
-}
+// Option represents a queue option.
+type Option func(q *Queue) error
 
-// Start the queue
-func (q *Queue) Start() {
-	for i := 0; i < q.maxWorker; i++ {
-		id := i + 1
-		worker := newWorker(id, q.JobRequests)
-		worker.start()
-	}
-
-	go q.dispatch()
-}
-
-// CollectJob Adds a job to the Queue
-func (q *Queue) CollectJob(job Job) {
-	WG.Add(1)
-	q.JobReceived <- job
-}
-
-func (q *Queue) dispatch() {
-	for {
-		select {
-		case job := <-q.JobReceived:
-			go func() {
-				jobRequest := <-q.JobRequests
-				jobRequest <- job
-			}()
+// Workers sets the number of workers which will process jobs from the queue.
+// The constant UnlimitedWorkers can be used along side dynamic workers, the default,
+// which will enable unlimited workers.
+// Default is runtime.NumCPU() workers.
+func Workers(count int) Option {
+	return func(q *Queue) error {
+		if count < UnlimitedWorkers {
+			return fmt.Errorf("workers must be at least %d, got %d", UnlimitedWorkers, count)
 		}
+
+		q.workers = count
+
+		return nil
+	}
+}
+
+// Limit sets the maximum number of jobs queued before an error is returned.
+// Default is DefaultLimit maximum queued jobs..
+func Limit(count int) Option {
+	return func(q *Queue) error {
+		if count < 0 {
+			return fmt.Errorf("limit must be at least 0, got %d", count)
+		}
+
+		q.limit = count
+
+		return nil
+	}
+}
+
+// Log sets the logger for Queue.
+// Default is log.Default().
+func Log(l Logger) Option {
+	return func(q *Queue) error {
+		q.log = l
+		return nil
+	}
+}
+
+// Static configures the Queue to use a static number of pre-spawned
+// workers instead of dynamic workers, which can be beneficial for
+// inexpensive jobs.
+// Default behaviour is to use dynamic workers.
+func Static() Option {
+	return func(q *Queue) error {
+		q.run = q.static
+		return nil
+	}
+}
+
+// New creates a fully initialised Queue with the given options.
+func New(options ...Option) (*Queue, error) {
+	q := &Queue{
+		workers: runtime.NumCPU(),
+		limit:   DefaultLimit,
+		log:     log.Default(),
+	}
+	q.run = q.dynamic
+
+	for _, f := range options {
+		if err := f(q); err != nil {
+			return nil, err
+		}
+	}
+
+	q.jobs = make(chan Job, q.limit)
+	if err := q.run(); err != nil {
+		return nil, err
+	}
+
+	return q, nil
+}
+
+// static spawns static workers.
+func (q *Queue) static() error {
+	if q.workers < 1 {
+		return fmt.Errorf("workers must be at least 1, got %d", q.workers)
+	}
+
+	q.log.Printf("Spawning %d static workers...", q.workers)
+	q.wg.Add(q.workers)
+
+	for i := 0; i < q.workers; i++ {
+		w := newWorker(q.jobs)
+		go func() {
+			defer q.wg.Done()
+			w.run()
+		}()
+	}
+
+	return nil
+}
+
+// dynamic processes jobs in goroutines.
+// This optimises for the case where not all goroutines are needed all the time
+// at the expense of having to start goroutines for each job.
+func (q *Queue) dynamic() error {
+	switch {
+	case q.workers == UnlimitedWorkers:
+		q.dynamicUnlimited()
+	case q.workers < 1:
+		return fmt.Errorf("workers must be at least 1, got %d", q.workers)
+	default:
+		q.dynamicLimited()
+	}
+	return nil
+}
+
+// dynamicUnlimited processes jobs with an unlimited number of goroutines.
+// This optimises for the case where not all goroutines are needed all the time
+// at the expense of having to start goroutines for each job.
+func (q *Queue) dynamicUnlimited() {
+	q.log.Printf("Using unlimited dynamic workers...", q.workers)
+	q.wg.Add(1)
+
+	go func() {
+		defer q.wg.Done()
+
+		for j := range q.jobs {
+			q.wg.Add(1)
+			go func(j Job) {
+				defer q.wg.Done()
+				j.Process()
+			}(j)
+		}
+	}()
+}
+
+// dynamicLimited processes jobs in a limited number of goroutines.
+// This optimises for the case where not all goroutines are needed all the time
+// at the expense of having to start goroutines for each job.
+func (q *Queue) dynamicLimited() {
+	q.log.Printf("Using up to %d dynamic workers...", q.workers)
+	q.wg.Add(1)
+	q.limiter = make(chan struct{}, q.workers)
+
+	go func() {
+		defer q.wg.Done()
+
+		for j := range q.jobs {
+			q.limiter <- struct{}{}
+			q.wg.Add(1)
+			go func(j Job) {
+				defer func() {
+					<-q.limiter
+					q.wg.Done()
+				}()
+				j.Process()
+			}(j)
+		}
+	}()
+}
+
+// Queue queues a job in blocking mode.
+func (q *Queue) Queue(job Job) {
+	q.jobs <- job
+}
+
+// QueueNonBlocking queues a job in non blocking mode.
+// If the maximum buffer as defined by Limit is already filled an error will be returned.
+func (q *Queue) QueueNonBlocking(job Job) error {
+	select {
+	case q.jobs <- job:
+		return nil
+	default:
+		return fmt.Errorf("too busy, already have %d queued jobs", cap(q.jobs))
+	}
+}
+
+// Stop stops processing and returns once all jobs have been completed
+// or the context indicates done.
+// The queue should not be used after calling Stop, calling Queue or QueueNonBlocking
+// after Stop will cause a panic.
+func (q *Queue) Stop(ctx context.Context) error {
+	close(q.jobs)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		q.wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -1,86 +1,143 @@
 package bqueue
 
 import (
-	"bytes"
-	"errors"
-	"fmt"
+	"context"
+	"io/ioutil"
 	"log"
-	"os"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-type aJob struct {
-	Name string
+type testJob struct {
+	processed bool
 }
 
-func (a aJob) Process() error {
-	if a.Name != "" {
-		log.Printf("test job: %s\n", a.Name)
-		return nil
+func (j *testJob) Process() {
+	j.processed = true
+}
+
+func discardLogger() Option {
+	return Log(log.New(ioutil.Discard, "", 0))
+}
+
+func testQueue(t *testing.T, expectErr bool, options ...Option) {
+	t.Helper()
+
+	q, err := New(options...)
+	if expectErr {
+		require.Error(t, err)
+		return
+	}
+	require.NoError(t, err)
+
+	jobs := make([]*testJob, 5)
+	for i := range jobs {
+		j := &testJob{}
+		jobs[i] = j
+		q.Queue(j)
 	}
 
-	return errors.New("could not print name")
-}
+	err = q.Stop(context.Background())
+	require.NoError(t, err)
 
-func Test_Collect_and_process_job(t *testing.T) {
-	q := New(1)
-	q.Start()
-	j := aJob{"Boo Foo"}
-
-	output := captureStout(func() {
-		q.CollectJob(j)
-	})
-
-	assert.Contains(t, output, "test job: Boo Foo", "The two words should be the same.")
-
-}
-
-func Test_WG(t *testing.T) {
-	q := New(1)
-	q.Start()
-
-	//var output string
-	var output string
-	output += captureStout(func() {
-		for i := 0; i <= 200; i++ {
-			j := aJob{strconv.Itoa(i)}
-			q.CollectJob(j)
-
-		}
-		WG.Wait()
-	})
-
-	// look for all instances of "test job: N"
-	// not very efficient but minimizes false positive
-	for i := 0; i <= 200; i++ {
-		if !strings.Contains(output, fmt.Sprintf("test job: %d", i)) {
-			t.FailNow()
-		}
+	for _, j := range jobs {
+		require.True(t, j.processed)
 	}
 }
 
-func captureStout(f func()) string {
-	var buf bytes.Buffer
-	output := ""
-	log.SetOutput(&buf)
-	start := time.Now()
-	f()
-	for {
-		elapse := time.Since(start).Seconds()
-		if elapse > float64(2) {
-			break
-		}
-		output += buf.String()
-		if output != "" {
-			break
-		}
+func TestOptions(t *testing.T) {
+	cases := []struct {
+		name    string
+		options []Option
+		err     bool
+	}{
+		{
+			name:    "logger",
+			options: []Option{discardLogger()},
+		},
+		{
+			name:    "valid-static-workers",
+			options: []Option{Static(), Workers(2), discardLogger()},
+		},
+		{
+			name:    "negative-static-workers",
+			options: []Option{Static(), Workers(-2), discardLogger()},
+			err:     true,
+		},
+		{
+			name:    "zero-static-workers",
+			options: []Option{Static(), Workers(0), discardLogger()},
+			err:     true,
+		},
+		{
+			name:    "unlimited-static-workers",
+			options: []Option{Static(), Workers(UnlimitedWorkers), discardLogger()},
+			err:     true,
+		},
+		{
+			name:    "valid-dynamic-workers",
+			options: []Option{Workers(2), discardLogger()},
+		},
+		{
+			name:    "negative-dynamic-workers",
+			options: []Option{Workers(-2), discardLogger()},
+			err:     true,
+		},
+		{
+			name:    "zero-dynamic-workers",
+			options: []Option{Workers(0), discardLogger()},
+			err:     true,
+		},
+		{
+			name:    "unlimited-dynamic-workers",
+			options: []Option{Workers(UnlimitedWorkers), discardLogger()},
+		},
+		{
+			name:    "valid-limit",
+			options: []Option{Limit(2), discardLogger()},
+		},
+		{
+			name:    "invalid-limit",
+			options: []Option{Limit(-2), discardLogger()},
+			err:     true,
+		},
 	}
 
-	log.SetOutput(os.Stderr)
-	return output
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testQueue(t, tc.err, tc.options...)
+		})
+	}
+}
+
+type testJobBlocking struct {
+}
+
+func (j *testJobBlocking) Process() {
+	<-time.After(time.Second)
+}
+
+func TestStop(t *testing.T) {
+	q, err := New(discardLogger())
+	require.NoError(t, err)
+	q.Queue(&testJobBlocking{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = q.Stop(ctx)
+	require.Error(t, err)
+}
+
+func BenchmarkQueue(b *testing.B) {
+	q, err := New(Workers(10), Static(), discardLogger())
+	require.NoError(b, err)
+
+	for n := 0; n < b.N; n++ {
+		q.Queue(&testJob{})
+	}
+
+	err = q.Stop(context.Background())
+	require.NoError(b, err)
 }


### PR DESCRIPTION
Refactor the queuing logic to:
* Eliminate unneeded global public mutex, which invalidate API boundaries.
* Eliminate multiple channel actions.
* Eliminate dedicated QuitChan in favour of closing the jobs channel.
* Eliminate exposed channels, which exposed internal logic making it subject to external breakage.
* Use channel ranging instead of for select loop.
* Add configurable options for:
  * Worker count
  * Worker type: dynamic or static
  * Limit for queued jobs
  * Logger

Also:
* Replace magic 128 with constant, detailing its function.
* Add tests and benchmark.
* Add blocking and non blocking queue methods.
* Add Stop method for shutting down the queue.
* Eliminate error output, which is a breaking change as the job interface is now Process() not Process() error.

Using static workers this reduces the amount of time to process a job from ~500ns to ~130ns.